### PR TITLE
chore(devcontainer): add port forwarding (#23)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,6 +11,9 @@ services:
     command: sleep infinity
     depends_on:
       - postgres
+    ports:
+      - "3000:3000"
+      - "80:80"
 
   postgres:
     image: postgres:17
@@ -21,6 +24,8 @@ services:
       POSTGRES_DB: scottystack
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

- Publish Vite (3000), Express API (80), and Postgres (5432) to the host via
  `ports` in `.devcontainer/docker-compose.yml`

Closes #23

## Acceptance criteria

- [x] `docker-compose.yml` publishes ports 3000, 80 on the `dev` service and 5432 on the `postgres` service
- [x] No changes to `devcontainer.json`

## Test plan

- [ ] Rebuild/reopen devcontainer and confirm localhost:3000, :80, and :5432 are reachable

Made with [Cursor](https://cursor.com)