### PR TITLE
refactor(forms): migrate post/reply forms to TanStack Form (#29)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "@scottystack/access-control": "workspace:*",
     "@scottystack/server": "workspace:*",
     "@tailwindcss/vite": "^4.0.6",
+    "@tanstack/react-form": "^1.33.0",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-router": "^1.166.3",
     "@tanstack/router-plugin": "^1.166.3",

--- a/apps/web/src/components/post/PostEditForm.tsx
+++ b/apps/web/src/components/post/PostEditForm.tsx
@@ -1,9 +1,11 @@
+import { useForm } from "@tanstack/react-form";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
 import { toast } from "react-toastify";
 
 import { Button } from "@/components/ui/button";
 import { $api } from "@/lib/apiClient";
+import { FieldError } from "@/lib/FieldError";
+import { postFormSchema } from "@/lib/formSchemas";
 
 interface PostEditFormProps {
   post: { id: string; title: string; content: string; anonymous?: boolean };
@@ -13,9 +15,6 @@ interface PostEditFormProps {
 
 export function PostEditForm({ post, onCancel, onSuccess }: PostEditFormProps) {
   const queryClient = useQueryClient();
-  const [title, setTitle] = useState(post.title);
-  const [content, setContent] = useState(post.content);
-  const [anonymous, setAnonymous] = useState(post.anonymous ?? false);
 
   const updatePost = $api.useMutation("patch", "/posts/{postId}", {
     onSuccess: async () => {
@@ -31,48 +30,93 @@ export function PostEditForm({ post, onCancel, onSuccess }: PostEditFormProps) {
     },
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!title.trim() || !content.trim()) return;
-    updatePost.mutate({
-      params: { path: { postId: post.id } },
-      body: { title: title.trim(), content: content.trim(), anonymous },
-    });
-  };
+  const form = useForm({
+    defaultValues: {
+      title: post.title,
+      content: post.content,
+      anonymous: post.anonymous ?? false,
+    },
+    validators: {
+      onChange: postFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      updatePost.mutate({
+        params: { path: { postId: post.id } },
+        body: {
+          title: value.title,
+          content: value.content,
+          anonymous: value.anonymous,
+        },
+      });
+    },
+  });
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <input
-        type="text"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        className="w-full rounded-md border border-input bg-background px-3 py-2 text-xl font-semibold ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        required
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        void form.handleSubmit();
+      }}
+      className="space-y-4"
+    >
+      <form.Field
+        name="title"
+        children={(field) => (
+          <div className="space-y-2">
+            <input
+              type="text"
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-xl font-semibold ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <FieldError field={field} />
+          </div>
+        )}
       />
-      <textarea
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        rows={8}
-        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        required
+      <form.Field
+        name="content"
+        children={(field) => (
+          <div className="space-y-2">
+            <textarea
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              rows={8}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <FieldError field={field} />
+          </div>
+        )}
       />
       <div className="flex items-center gap-4">
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={anonymous}
-            onChange={(e) => setAnonymous(e.target.checked)}
-            className="rounded border-input"
-          />
-          Post anonymously
-        </label>
+        <form.Field
+          name="anonymous"
+          children={(field) => (
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.checked)}
+                className="rounded border-input"
+              />
+              Post anonymously
+            </label>
+          )}
+        />
         <div className="flex gap-2">
           <Button type="button" variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="submit" disabled={updatePost.isPending}>
-            {updatePost.isPending ? "Saving..." : "Save"}
-          </Button>
+          <form.Subscribe
+            selector={(state) => state.isSubmitting}
+            children={(isSubmitting) => (
+              <Button type="submit" disabled={isSubmitting || updatePost.isPending}>
+                {updatePost.isPending ? "Saving..." : "Save"}
+              </Button>
+            )}
+          />
         </div>
       </div>
     </form>

--- a/apps/web/src/components/post/ReplyForm.tsx
+++ b/apps/web/src/components/post/ReplyForm.tsx
@@ -1,9 +1,11 @@
+import { useForm } from "@tanstack/react-form";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
 import { toast } from "react-toastify";
 
 import { Button } from "@/components/ui/button";
 import { $api } from "@/lib/apiClient";
+import { FieldError } from "@/lib/FieldError";
+import { replyFormSchema } from "@/lib/formSchemas";
 
 interface ReplyFormProps {
   postId: string;
@@ -11,8 +13,6 @@ interface ReplyFormProps {
 
 export function ReplyForm({ postId }: ReplyFormProps) {
   const queryClient = useQueryClient();
-  const [content, setContent] = useState("");
-  const [anonymous, setAnonymous] = useState(false);
 
   const createReply = $api.useMutation("post", "/posts/{postId}/replies", {
     onSuccess: () => {
@@ -22,43 +22,81 @@ export function ReplyForm({ postId }: ReplyFormProps) {
         }).queryKey,
       });
       toast.success("Reply posted");
-      setContent("");
     },
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!content.trim()) return;
-    createReply.mutate({
-      params: { path: { postId } },
-      body: { content: content.trim(), anonymous },
-    });
-  };
+  const form = useForm({
+    defaultValues: {
+      content: "",
+      anonymous: false,
+    },
+    validators: {
+      onChange: replyFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      createReply.mutate(
+        {
+          params: { path: { postId } },
+          body: { content: value.content, anonymous: value.anonymous },
+        },
+        {
+          onSuccess: () => {
+            form.reset();
+          },
+        },
+      );
+    },
+  });
 
   return (
-    <form onSubmit={handleSubmit} className="mt-8 border-t pt-6">
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        void form.handleSubmit();
+      }}
+      className="mt-8 border-t pt-6"
+    >
       <h2 className="mb-4 text-sm font-medium text-muted-foreground">Reply</h2>
-      <textarea
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        placeholder="Write your reply..."
-        rows={4}
-        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        required
+      <form.Field
+        name="content"
+        children={(field) => (
+          <div className="space-y-2">
+            <textarea
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              placeholder="Write your reply..."
+              rows={4}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <FieldError field={field} />
+          </div>
+        )}
       />
       <div className="mt-2 flex items-center gap-4">
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={anonymous}
-            onChange={(e) => setAnonymous(e.target.checked)}
-            className="rounded border-input"
-          />
-          Post anonymously
-        </label>
-        <Button type="submit" disabled={createReply.isPending}>
-          {createReply.isPending ? "Posting..." : "Reply"}
-        </Button>
+        <form.Field
+          name="anonymous"
+          children={(field) => (
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.checked)}
+                className="rounded border-input"
+              />
+              Post anonymously
+            </label>
+          )}
+        />
+        <form.Subscribe
+          selector={(state) => state.isSubmitting}
+          children={(isSubmitting) => (
+            <Button type="submit" disabled={isSubmitting || createReply.isPending}>
+              {createReply.isPending ? "Posting..." : "Reply"}
+            </Button>
+          )}
+        />
       </div>
     </form>
   );

--- a/apps/web/src/components/post/ReplyItem.tsx
+++ b/apps/web/src/components/post/ReplyItem.tsx
@@ -1,11 +1,13 @@
 import type { User } from "@scottystack/access-control";
 import { hasPermission } from "@scottystack/access-control";
+import { useForm } from "@tanstack/react-form";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
 import { toast } from "react-toastify";
 
 import { Button } from "@/components/ui/button";
 import { $api } from "@/lib/apiClient";
+import { FieldError } from "@/lib/FieldError";
+import { replyFormSchema } from "@/lib/formSchemas";
 
 interface ReplyItemProps {
   reply: {
@@ -24,20 +26,14 @@ interface ReplyItemProps {
   onEndEdit: () => void;
 }
 
-export function ReplyItem({
-  reply,
-  user,
-  postId,
-  isEditing,
-  onStartEdit,
-  onEndEdit,
-}: ReplyItemProps) {
-  const queryClient = useQueryClient();
-  const [editContent, setEditContent] = useState(reply.content);
-  const [editAnonymous, setEditAnonymous] = useState(reply.anonymous ?? false);
+interface ReplyEditFormProps {
+  reply: ReplyItemProps["reply"];
+  postId: string;
+  onEndEdit: () => void;
+}
 
-  const canUpdate = hasPermission(user, "replies", "update", reply);
-  const canDelete = hasPermission(user, "replies", "delete", reply);
+function ReplyEditForm({ reply, postId, onEndEdit }: ReplyEditFormProps) {
+  const queryClient = useQueryClient();
 
   const updateReply = $api.useMutation("patch", "/posts/{postId}/replies/{replyId}", {
     onSuccess: () => {
@@ -51,6 +47,100 @@ export function ReplyItem({
     },
   });
 
+  const form = useForm({
+    defaultValues: {
+      content: reply.content,
+      anonymous: reply.anonymous ?? false,
+    },
+    validators: {
+      onChange: replyFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      updateReply.mutate({
+        params: { path: { postId, replyId: reply.id } },
+        body: { content: value.content, anonymous: value.anonymous },
+      });
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        void form.handleSubmit();
+      }}
+      className="rounded-lg border p-4"
+    >
+      <form.Field
+        name="content"
+        children={(field) => (
+          <div className="space-y-2">
+            <textarea
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              rows={4}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <FieldError field={field} />
+          </div>
+        )}
+      />
+      <div className="mt-2 flex items-center gap-4">
+        <form.Field
+          name="anonymous"
+          children={(field) => (
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.checked)}
+                className="rounded border-input"
+              />
+              Post anonymously
+            </label>
+          )}
+        />
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              form.reset();
+              onEndEdit();
+            }}
+          >
+            Cancel
+          </Button>
+          <form.Subscribe
+            selector={(state) => state.isSubmitting}
+            children={(isSubmitting) => (
+              <Button type="submit" size="sm" disabled={isSubmitting || updateReply.isPending}>
+                {updateReply.isPending ? "Saving..." : "Save"}
+              </Button>
+            )}
+          />
+        </div>
+      </div>
+    </form>
+  );
+}
+
+export function ReplyItem({
+  reply,
+  user,
+  postId,
+  isEditing,
+  onStartEdit,
+  onEndEdit,
+}: ReplyItemProps) {
+  const queryClient = useQueryClient();
+
+  const canUpdate = hasPermission(user, "replies", "update", reply);
+  const canDelete = hasPermission(user, "replies", "delete", reply);
+
   const deleteReply = $api.useMutation("delete", "/posts/{postId}/replies/{replyId}", {
     onSuccess: () => {
       void queryClient.invalidateQueries({
@@ -62,14 +152,6 @@ export function ReplyItem({
       onEndEdit();
     },
   });
-
-  const handleSave = () => {
-    if (!editContent.trim()) return;
-    updateReply.mutate({
-      params: { path: { postId, replyId: reply.id } },
-      body: { content: editContent.trim(), anonymous: editAnonymous },
-    });
-  };
 
   const handleDelete = () => {
     if (confirm("Delete this reply?")) {
@@ -87,44 +169,7 @@ export function ReplyItem({
   });
 
   if (isEditing) {
-    return (
-      <div className="rounded-lg border p-4">
-        <textarea
-          value={editContent}
-          onChange={(e) => setEditContent(e.target.value)}
-          rows={4}
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        />
-        <div className="mt-2 flex items-center gap-4">
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={editAnonymous}
-              onChange={(e) => setEditAnonymous(e.target.checked)}
-              className="rounded border-input"
-            />
-            Post anonymously
-          </label>
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setEditContent(reply.content);
-                setEditAnonymous(reply.anonymous ?? false);
-                onEndEdit();
-              }}
-            >
-              Cancel
-            </Button>
-            <Button type="button" size="sm" onClick={handleSave} disabled={updateReply.isPending}>
-              {updateReply.isPending ? "Saving..." : "Save"}
-            </Button>
-          </div>
-        </div>
-      </div>
-    );
+    return <ReplyEditForm reply={reply} postId={postId} onEndEdit={onEndEdit} />;
   }
 
   return (

--- a/apps/web/src/components/posts/NewPostForm.tsx
+++ b/apps/web/src/components/posts/NewPostForm.tsx
@@ -1,17 +1,16 @@
+import { useForm } from "@tanstack/react-form";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
 import { toast } from "react-toastify";
 
 import { Button } from "@/components/ui/button";
 import { $api } from "@/lib/apiClient";
+import { FieldError } from "@/lib/FieldError";
+import { postFormSchema } from "@/lib/formSchemas";
 
 export function NewPostForm() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [title, setTitle] = useState("");
-  const [content, setContent] = useState("");
-  const [anonymous, setAnonymous] = useState(false);
 
   const createPost = $api.useMutation("post", "/posts", {
     onSuccess: () => {
@@ -21,69 +20,106 @@ export function NewPostForm() {
     },
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!title.trim() || !content.trim()) return;
-    createPost.mutate({
-      body: {
-        title: title.trim(),
-        content: content.trim(),
-        anonymous,
-      },
-    });
-  };
+  const form = useForm({
+    defaultValues: {
+      title: "",
+      content: "",
+      anonymous: false,
+    },
+    validators: {
+      onChange: postFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      createPost.mutate({
+        body: {
+          title: value.title,
+          content: value.content,
+          anonymous: value.anonymous,
+        },
+      });
+    },
+  });
 
   return (
-    <form onSubmit={handleSubmit} className="mx-auto max-w-2xl space-y-6">
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        void form.handleSubmit();
+      }}
+      className="mx-auto max-w-2xl space-y-6"
+    >
       <h1 className="text-xl font-semibold">New Post</h1>
 
-      <div className="space-y-2">
-        <label htmlFor="title" className="block text-sm font-medium">
-          Title
-        </label>
-        <input
-          id="title"
-          type="text"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="Title"
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          required
-        />
-      </div>
+      <form.Field
+        name="title"
+        children={(field) => (
+          <div className="space-y-2">
+            <label htmlFor="title" className="block text-sm font-medium">
+              Title
+            </label>
+            <input
+              id="title"
+              type="text"
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              placeholder="Title"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <FieldError field={field} />
+          </div>
+        )}
+      />
 
-      <div className="space-y-2">
-        <label htmlFor="post-content" className="block text-sm font-medium">
-          Content
-        </label>
-        <textarea
-          id="post-content"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          placeholder="Write your post..."
-          rows={8}
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          required
-        />
-      </div>
+      <form.Field
+        name="content"
+        children={(field) => (
+          <div className="space-y-2">
+            <label htmlFor="post-content" className="block text-sm font-medium">
+              Content
+            </label>
+            <textarea
+              id="post-content"
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+              placeholder="Write your post..."
+              rows={8}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <FieldError field={field} />
+          </div>
+        )}
+      />
 
       <div className="flex items-center justify-between">
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={anonymous}
-            onChange={(e) => setAnonymous(e.target.checked)}
-            className="rounded border-input"
-          />
-          Post anonymously
-        </label>
+        <form.Field
+          name="anonymous"
+          children={(field) => (
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(e.target.checked)}
+                className="rounded border-input"
+              />
+              Post anonymously
+            </label>
+          )}
+        />
         <div className="flex gap-2">
           <Button type="button" variant="outline" onClick={() => navigate({ to: "/" })}>
             Cancel
           </Button>
-          <Button type="submit" disabled={createPost.isPending}>
-            {createPost.isPending ? "Posting..." : "Post"}
-          </Button>
+          <form.Subscribe
+            selector={(state) => state.isSubmitting}
+            children={(isSubmitting) => (
+              <Button type="submit" disabled={isSubmitting || createPost.isPending}>
+                {createPost.isPending ? "Posting..." : "Post"}
+              </Button>
+            )}
+          />
         </div>
       </div>
     </form>

--- a/apps/web/src/lib/FieldError.tsx
+++ b/apps/web/src/lib/FieldError.tsx
@@ -1,0 +1,10 @@
+import type { AnyFieldApi } from "@tanstack/react-form";
+
+interface FieldErrorProps {
+  field: AnyFieldApi;
+}
+
+export function FieldError({ field }: FieldErrorProps) {
+  if (!field.state.meta.isTouched || field.state.meta.isValid) return null;
+  return <p className="text-destructive text-sm">{field.state.meta.errors.join(", ")}</p>;
+}

--- a/apps/web/src/lib/formSchemas.ts
+++ b/apps/web/src/lib/formSchemas.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const postFormSchema = z.object({
+  title: z.string().trim().min(1, "Title is required"),
+  content: z.string().trim().min(1, "Content is required"),
+  anonymous: z.boolean(),
+});
+
+export const replyFormSchema = z.object({
+  content: z.string().trim().min(1, "Reply is required"),
+  anonymous: z.boolean(),
+});
+
+export type PostFormValues = z.infer<typeof postFormSchema>;
+export type ReplyFormValues = z.infer<typeof replyFormSchema>;

--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "@scottystack/access-control": "workspace:*",
         "@scottystack/server": "workspace:*",
         "@tailwindcss/vite": "^4.0.6",
+        "@tanstack/react-form": "^1.33.0",
         "@tanstack/react-query": "^5.90.20",
         "@tanstack/react-router": "^1.166.3",
         "@tanstack/router-plugin": "^1.166.3",
@@ -812,13 +813,19 @@
 
     "@tanstack/devtools-vite": ["@tanstack/devtools-vite@0.8.1", "", { "dependencies": { "@tanstack/devtools-client": "0.0.8", "@tanstack/devtools-event-bus": "0.4.2", "chalk": "^5.6.2", "launch-editor": "^2.11.1", "magic-string": "^0.30.0", "oxc-parser": "^0.120.0", "picomatch": "^4.0.3" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-oQxOo0fI0bwhHtw/psFlIR0OS/bsKrirBxwnw2vuhCM4bjt3k4EZZsW/lvZ1+Vpouhts7LSyvngnxvGXbQ1sUQ=="],
 
+    "@tanstack/form-core": ["@tanstack/form-core@1.33.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1", "@tanstack/pacer-lite": "^0.1.1", "@tanstack/store": "^0.11.0" } }, "sha512-AV4Pw9Dk4orFsuPBcDssfWMJFs+yMYBae7zZ4oTqrCf4ftNGQKxvrQRZeqKHG6A4TkiLeSvf2kzIjcVkrW7E6w=="],
+
     "@tanstack/history": ["@tanstack/history@1.161.4", "", {}, "sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww=="],
+
+    "@tanstack/pacer-lite": ["@tanstack/pacer-lite@0.1.1", "", {}, "sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
     "@tanstack/query-devtools": ["@tanstack/query-devtools@5.93.0", "", {}, "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg=="],
 
     "@tanstack/react-devtools": ["@tanstack/react-devtools@0.7.11", "", { "dependencies": { "@tanstack/devtools": "0.7.0" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-a2Lmz8x+JoDrsU6f7uKRcyyY+k8mA/n5mb9h7XJ3Fz/y3+sPV9t7vAW1s5lyNkQyyDt6V1Oim99faLthoJSxMw=="],
+
+    "@tanstack/react-form": ["@tanstack/react-form@1.33.0", "", { "dependencies": { "@tanstack/form-core": "1.33.0", "@tanstack/react-store": "^0.11.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-unaee+VS4MvKo+s1dmgGUXI4902VeAhuaUbKsQbhFe3MceOpB3JpAUGCDpyzjQPXVFkFY0COKfLrUNX2XZYW4g=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.20", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw=="],
 
@@ -828,7 +835,7 @@
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.158.1", "", { "dependencies": { "@tanstack/router-devtools-core": "1.158.1" }, "peerDependencies": { "@tanstack/react-router": "^1.158.1", "@tanstack/router-core": "^1.158.1", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-H0iTfsLNkadF/JhJnu/pUxlxOiLjE0866vFqXK/7EYVcyYwx2uWQuGxEkyF7a04oXXrbEImAOoXDRBQcZ9T5Zw=="],
 
-    "@tanstack/react-store": ["@tanstack/react-store@0.9.2", "", { "dependencies": { "@tanstack/store": "0.9.2", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Vt5usJE5sHG/cMechQfmwvwne6ktGCELe89Lmvoxe3LKRoFrhPa8OCKWs0NliG8HTJElEIj7PLtaBQIcux5pAQ=="],
+    "@tanstack/react-store": ["@tanstack/react-store@0.11.0", "", { "dependencies": { "@tanstack/store": "0.11.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.166.2", "", { "dependencies": { "@tanstack/history": "1.161.4", "@tanstack/store": "^0.9.1", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" } }, "sha512-zn3NhENOAX9ToQiX077UV2OH3aJKOvV2ZMNZZxZ3gDG3i3WqL8NfWfEgetEAfMN37/Mnt90PpotYgf7IyuoKqQ=="],
 
@@ -2187,6 +2194,14 @@
     "@tanstack/devtools/@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.3", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.3.3" } }, "sha512-kl0r6N5iIL3t9gGDRAv55VRM3UIyMKVH83esRGq7xBjYsRLe/BeCIN2HqrlJkObUXQMKhy7i8ejuGOn+bDqDBw=="],
 
     "@tanstack/devtools/@tanstack/devtools-event-bus": ["@tanstack/devtools-event-bus@0.3.3", "", { "dependencies": { "ws": "^8.18.3" } }, "sha512-lWl88uLAz7ZhwNdLH6A3tBOSEuBCrvnY9Fzr5JPdzJRFdM5ZFdyNWz1Bf5l/F3GU57VodrN0KCFi9OA26H5Kpg=="],
+
+    "@tanstack/form-core/@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.4", "", { "bin": { "intent": "./bin/intent.js" } }, "sha512-6T5Yop/793YI+H+5J8Hsyj4kCih9sl4t3ElLgKioW5hk3ocn+ZdSJ94tT7vL7uabxSugWYBZlOTMPzEw2puvQw=="],
+
+    "@tanstack/form-core/@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
+
+    "@tanstack/react-router/@tanstack/react-store": ["@tanstack/react-store@0.9.2", "", { "dependencies": { "@tanstack/store": "0.9.2", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Vt5usJE5sHG/cMechQfmwvwne6ktGCELe89Lmvoxe3LKRoFrhPa8OCKWs0NliG8HTJElEIj7PLtaBQIcux5pAQ=="],
+
+    "@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
 
     "@tanstack/router-generator/@tanstack/router-core": ["@tanstack/router-core@1.171.13", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA=="],
 

--- a/docs/adr/0001-tanstack-form.md
+++ b/docs/adr/0001-tanstack-form.md
@@ -1,0 +1,23 @@
+# ADR 0001: TanStack Form for client-side forms
+
+## Status
+
+Accepted
+
+## Context
+
+Post and reply forms in `apps/web` previously used ad-hoc `useState` with manual trim checks and HTML `required` attributes. The project already uses TanStack Query and TanStack Router. We need a form library that aligns with that stack and supports schema-driven validation as forms grow.
+
+## Decision
+
+Use `@tanstack/react-form` with Zod schemas for all post/reply form UIs in `apps/web`.
+
+- **TanStack Form over react-hook-form**: Keeps the client stack consistent (Query, Router, Form) and shares similar headless, composable patterns.
+- **Zod via Standard Schema**: TanStack Form accepts Zod schemas directly in `validators` without a separate adapter. Shared schemas live in `apps/web/src/lib/formSchemas.ts`.
+- **Minimal abstractions**: No shared Input/Textarea field wrapper components. Each form uses `form.Field` render props inline. A tiny `FieldError` helper renders touched-field validation messages only.
+
+## Consequences
+
+- Form validation is centralized in Zod schemas; submit handlers no longer duplicate trim/required checks.
+- Inline errors appear when a field is touched and invalid.
+- Future forms should follow the same pattern: shared schema + inline `form.Field` + `FieldError`.


### PR DESCRIPTION
## Summary

Migrates all four post/reply form UIs in `apps/web` from ad-hoc `useState` validation to `@tanstack/react-form` with shared Zod schemas and visible inline validation errors.

Closes #29

## Acceptance Criteria

- [x] @tanstack/react-form added to apps/web
- [x] Shared Zod schemas for post (title, content, anonymous) and reply (content, anonymous) fields
- [x] NewPostForm, PostEditForm, ReplyForm migrated to TanStack Form
- [x] ReplyItem inline edit migrated to TanStack Form
- [x] Inline validation errors shown for invalid touched fields
- [x] Existing UX preserved: mutations, toasts, navigation, query invalidation, cancel/reset
- [x] bun run lint and bun run format pass

## Test plan

- [ ] Create post with empty title/content → inline errors after blur/submit
- [ ] Create valid post → toast, navigate to home, post appears in list
- [ ] Edit post, change fields, cancel → reverts to view mode without saving
- [ ] Edit post, save valid changes → toast, updated content shown
- [ ] Reply with empty content → inline error after blur/submit
- [ ] Submit valid reply → toast, form clears, reply appears
- [ ] Edit reply inline, cancel → reverts to original content
- [ ] Edit reply inline, save → toast, updated reply shown

## Additional notes

- ADR: `docs/adr/0001-tanstack-form.md`
- Minimal abstractions: shared Zod schemas + `FieldError` helper only; `form.Field` render props stay inline per component

Made with [Cursor](https://cursor.com)