### PR TITLE
feat(web): add skeleton loading states (#31)

### DIFF
--- a/apps/web/src/components/dashboard/DashboardUsersTableSkeleton.tsx
+++ b/apps/web/src/components/dashboard/DashboardUsersTableSkeleton.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const SKELETON_ROW_COUNT = 5;
+
+export function DashboardUsersTableSkeleton() {
+  return (
+    <div className="flex flex-col p-6">
+      <Skeleton className="mb-4 h-8 w-48" />
+      <p className="mb-6 text-sm text-muted-foreground">All users with post and reply counts.</p>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>User ID</TableHead>
+            <TableHead>User name</TableHead>
+            <TableHead>Number of posts</TableHead>
+            <TableHead>Number of replies</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
+            <TableRow key={index}>
+              <TableCell>
+                <Skeleton className="h-4 w-32" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-4 w-24" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-4 w-8" />
+              </TableCell>
+              <TableCell>
+                <Skeleton className="h-4 w-8" />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/apps/web/src/components/post/PostDetailSkeleton.tsx
+++ b/apps/web/src/components/post/PostDetailSkeleton.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function PostDetailSkeleton() {
+  return (
+    <div className="flex flex-col p-6">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-2/3" />
+        <Skeleton className="h-4 w-1/3" />
+      </div>
+      <div className="mt-4 space-y-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/posts/PostList.tsx
+++ b/apps/web/src/components/posts/PostList.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from "@tanstack/react-router";
 import { Pencil } from "lucide-react";
 import InfiniteScroll from "react-infinite-scroll-component";
 
+import { PostListSkeleton } from "@/components/posts/PostListSkeleton";
 import { buttonVariants } from "@/components/ui/button";
 import { $api } from "@/lib/apiClient";
 import { useSession } from "@/lib/authClient";
@@ -53,11 +54,7 @@ export function PostList() {
   const posts = data?.pages.flatMap((p) => p.posts) ?? [];
 
   if (isLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-4 text-sm text-muted-foreground">
-        Loading posts...
-      </div>
-    );
+    return <PostListSkeleton />;
   }
 
   if (isError) {
@@ -96,9 +93,11 @@ export function PostList() {
             next={fetchNextPage}
             hasMore={hasNextPage ?? false}
             loader={
-              <div className="p-4 text-center text-sm text-muted-foreground">
-                {isFetchingNextPage ? "Loading more..." : null}
-              </div>
+              isFetchingNextPage ? (
+                <div className="p-4">
+                  <PostListSkeleton count={2} />
+                </div>
+              ) : null
             }
             scrollableTarget="post-list-scroll"
           >

--- a/apps/web/src/components/posts/PostListSkeleton.tsx
+++ b/apps/web/src/components/posts/PostListSkeleton.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+type PostListSkeletonProps = {
+  count?: number;
+};
+
+export function PostListSkeleton({ count = 5 }: PostListSkeletonProps) {
+  return (
+    <div className="flex flex-col">
+      {Array.from({ length: count }, (_, index) => (
+        <div key={index} className="border-b px-4 py-3">
+          <div className="flex items-start gap-2">
+            <Skeleton className="mt-1.5 size-2 shrink-0 rounded-full" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/apps/web/src/routes/$postId.tsx
+++ b/apps/web/src/routes/$postId.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 
+import { PostDetailSkeleton } from "@/components/post/PostDetailSkeleton";
 import { PostEditForm } from "@/components/post/PostEditForm";
 import { PostHeader } from "@/components/post/PostHeader";
 import { ReplyForm } from "@/components/post/ReplyForm";
@@ -17,11 +18,7 @@ export const Route = createFileRoute("/$postId")({
       }),
     );
   },
-  pendingComponent: () => (
-    <div className="flex flex-1 items-center justify-center p-4 text-sm text-muted-foreground">
-      Loading...
-    </div>
-  ),
+  pendingComponent: PostDetailSkeleton,
   errorComponent: ({ error }) => (
     <div className="p-6 text-sm text-destructive">
       Error: {error ? String(error) : "Failed to load post"}

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
+import { DashboardUsersTableSkeleton } from "@/components/dashboard/DashboardUsersTableSkeleton";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -34,11 +35,7 @@ function DashboardPage() {
   });
 
   if (sessionPending) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-4 text-sm text-muted-foreground">
-        Loading...
-      </div>
-    );
+    return <DashboardUsersTableSkeleton />;
   }
 
   if (!auth?.user) {
@@ -59,11 +56,7 @@ function DashboardPage() {
   }
 
   if (usersLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-4 text-sm text-muted-foreground">
-        Loading users...
-      </div>
-    );
+    return <DashboardUsersTableSkeleton />;
   }
 
   if (usersError) {


### PR DESCRIPTION
## Summary
- Add shadcn `Skeleton` primitive to `apps/web`
- Replace plain-text loading states with layout-matched skeleton placeholders on post list, post detail, and admin dashboard

Reopened as a fresh PR to trigger Railway preview deployment.

## Acceptance criteria
- [x] `Skeleton` exported from `@/components/ui/skeleton`
- [x] Post list initial load shows ~5 skeleton rows matching post item layout
- [x] Post list infinite-scroll loader shows 2 skeleton rows
- [x] Post detail `pendingComponent` shows skeleton header + content lines
- [x] Dashboard session-pending and users-loading show skeleton table with static headers
- [x] No remaining plain-text loading strings in those files
- [x] Lint and format pass

Closes #31

## Test plan
- [ ] Load `/` with network throttled: sidebar shows skeleton post rows
- [ ] Scroll post list to trigger pagination: bottom shows 2 skeleton rows
- [ ] Navigate to a post: right pane shows header + body skeleton during route pending
- [ ] Visit `/dashboard` as admin with throttling: table skeleton with column headers visible
- [ ] Confirm Railway preview deployment triggers for this PR

Made with [Cursor](https://cursor.com)