### PR TITLE
feat(secrets): merge generated and original OpenBao secrets on pull

### DIFF
--- a/scripts/secrets/config.sh
+++ b/scripts/secrets/config.sh
@@ -4,3 +4,4 @@ export BAO_MOUNT="labrador"
 export PROJECT="scottystack"
 export APPS="web server"
 export ENVS="local dev staging prod"
+export EMPTY_JSON='{"data":{"data":{}}}'

--- a/scripts/secrets/pull.sh
+++ b/scripts/secrets/pull.sh
@@ -13,9 +13,50 @@ pull() {
   local env_path="$1"
   local bao_path="$2"
   bao_path="$BAO_MOUNT/$bao_path"
-  echo -e "${BLUE_TEXT}Pulling from \"$bao_path\" to \"$env_path\"${RESET_TEXT}"
-  bao kv get -format=json "$bao_path" |
-    jq -r '.data.data | to_entries[] | "\(.key)=\"\(.value)\""' >$env_path
+
+  # e.g. labrador/scottystack/local/web -> labrador/scottystack/generated/local/web
+  local generated_path
+  generated_path=$(sed 's|^[^/]*/[^/]*|&/generated|' <<<"$bao_path")
+
+  echo -e "${BLUE_TEXT}Pulling from \"$generated_path\" and \"$bao_path\" to \"$env_path\"${RESET_TEXT}"
+
+  # Fetch the generated secrets
+  local generated_json=$EMPTY_JSON
+  local fetched_generated_json
+  set +e
+  fetched_generated_json=$(bao kv get -format=json "$generated_path" 2>/dev/null)
+  set -e
+  if [ -n "$fetched_generated_json" ]; then
+    generated_json=$fetched_generated_json
+  fi
+
+  # Fetch the secrets from the original path
+  local original_json=$EMPTY_JSON
+  local fetched_original_json
+  set +e
+  fetched_original_json=$(bao kv get -format=json "$bao_path" 2>/dev/null)
+  set -e
+  if [ -n "$fetched_original_json" ]; then
+    original_json=$fetched_original_json
+  fi
+
+  # If no secrets found, exit with an error
+  if [ "$generated_json" = $EMPTY_JSON ] && [ "$original_json" = $EMPTY_JSON ]; then
+    echo -e "${RED_TEXT}Error: No secrets found at \"$generated_path\" or \"$bao_path\"${RESET_TEXT}" >&2
+    exit 1
+  fi
+
+  # Merge the secrets with the original secrets overriding the generated secrets
+  # and write to the environment file
+  local env_content
+  env_content=$(
+    jq -r -s \
+      '(.[0].data.data // {}) * (.[1].data.data // {}) | to_entries[] | "\(.key)=\"\(.value)\""' \
+      <(printf '%s' "$generated_json") \
+      <(printf '%s' "$original_json")
+  )
+
+  printf '%s\n' "$env_content" >"$env_path"
 }
 
 # Run the pull


### PR DESCRIPTION
## Summary
- Pull secrets from both the generated OpenBao path and the path-specific path
- Merge with path-specific secrets overriding generated defaults
- Handle missing paths gracefully without aborting when one source exists

## Test plan
- [ ] Run `bun run secrets:pull` for an app/env with only generated secrets
- [ ] Run `bun run secrets:pull` for an app/env with overrides at the original path
- [ ] Verify merged `.env.*` files contain expected values


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secret pulling now combines values from two locations, allowing generated secrets and existing secrets to be merged into the final environment output.
* **Bug Fixes**
  * Improved handling when one secret location is missing, so the pull process continues if the other path still provides data.
  * Added a clear failure message when no secrets can be retrieved, instead of producing an empty result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->