### PR TITLE
fix: render field validation error messages instead of [object Object] (#52)

### DIFF
--- a/apps/web/src/lib/FieldError.tsx
+++ b/apps/web/src/lib/FieldError.tsx
@@ -4,7 +4,20 @@ interface FieldErrorProps {
   field: AnyFieldApi;
 }
 
+// Standard-schema validators (e.g. Zod) produce issue objects, not strings,
+// so joining the raw errors would render "[object Object]".
+function errorMessage(error: unknown): string {
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error);
+}
+
 export function FieldError({ field }: FieldErrorProps) {
   if (!field.state.meta.isTouched || field.state.meta.isValid) return null;
-  return <p className="text-destructive text-sm">{field.state.meta.errors.join(", ")}</p>;
+  return (
+    <p className="text-destructive text-sm">
+      {field.state.meta.errors.map(errorMessage).join(", ")}
+    </p>
+  );
 }


### PR DESCRIPTION
## Summary
- Fix the shared `FieldError` component (`apps/web/src/lib/FieldError.tsx`) so field validation errors render their human-readable messages instead of `[object Object]`.
- Root cause: forms pass Zod schemas to TanStack Form's standard-schema validators, which put issue *objects* in `field.state.meta.errors`; the old `errors.join(", ")` stringified each object to `[object Object]`. The fix extracts each error's `.message` (with a `String(error)` fallback for non-object errors).
- Fixes all four consumers: New Post, Edit Post, Reply, and Edit Reply forms.

## Acceptance criteria
- [x] Field validation errors display their human-readable messages (e.g. "Title is required"), never `[object Object]`.
- [x] Fix applies everywhere `FieldError` is used: New Post, Edit Post, Reply, and Edit Reply forms.
- [x] `turbo run quality` (lint + format) passes.

Closes #52

## Test plan
- [x] Verified in the browser: submitting an empty New Post form now shows "Title is required" / "Content is required".
- [x] `bunx turbo run quality` passes locally.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error display by showing clear messages from structured errors.
  * Preserved existing error visibility and styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->